### PR TITLE
change return type of `DoubleTapConfig.onDoubleTap` from `Widget` to `Void`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,3 +17,7 @@ initial release
 ## 1.0.3
 
 - change param type of `DoubleTapConfig.onDoubleTap`
+
+## 1.0.4
+
+- change return type of `DoubleTapConfig.onDoubleTap` from `Widget` to `Void`

--- a/lib/src/widgets.dart
+++ b/lib/src/widgets.dart
@@ -24,7 +24,7 @@ typedef TextBuilder = String Function(Lr lr, int tapCount);
 typedef SwipeOverlayBuilder = Widget Function(SwipeData data);
 
 /// Signature of callback that have [lr]
-typedef DoubleTapCallback = Widget Function(Lr lr);
+typedef DoubleTapCallback = void Function(Lr lr);
 
 /// widget to detect double tap and horizontal drag.
 /// this widget is usual to handle fast forward/rewind behavior like a video player.

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: double_tap_player_view
 description: a widget to handle fast forward/rewind behavior by double tap and horizontal drag like a video player.
-version: 1.0.3
+version: 1.0.4
 homepage: https://github.com/HiroyukTamura/double_tap_player_view
 repository: https://github.com/HiroyukTamura/double_tap_player_view
 


### PR DESCRIPTION
- add changelog
- change return type of `DoubleTapConfig.onDoubleTap` from `Widget` to `Void`